### PR TITLE
Deploy the snark verifier contracts in the MACI contract constructor

### DIFF
--- a/contracts/sol/MACI.sol
+++ b/contracts/sol/MACI.sol
@@ -5,13 +5,16 @@ import { Hasher } from "./Hasher.sol";
 import { DomainObjs } from './DomainObjs.sol';
 import { MerkleTree } from "./MerkleTree.sol";
 import { SignUpGatekeeper } from "./gatekeepers/SignUpGatekeeper.sol";
-import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
 import { BatchUpdateStateTreeVerifier } from "./BatchUpdateStateTreeVerifier.sol";
+import { QuadVoteTallyVerifier } from "./QuadVoteTallyVerifier.sol";
+
+import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
 
 contract MACI is Hasher, Ownable, DomainObjs {
 
     // Verifier Contracts
     BatchUpdateStateTreeVerifier internal batchUstVerifier;
+    QuadVoteTallyVerifier internal qvtVerifier;
 
     // TODO: remove the update function if it isn't used
     MerkleTree public messageTree;
@@ -56,15 +59,15 @@ contract MACI is Hasher, Ownable, DomainObjs {
         uint8 _messageTreeDepth,
         uint8 _stateTreeDepth,
         uint8 voteOptionTreeDepth,
-        BatchUpdateStateTreeVerifier _batchUstVerifier,
         SignUpGatekeeper _signUpGatekeeper,
         uint256 _signUpDurationSeconds,
         uint256 _initialVoiceCreditBalance,
         PubKey memory _coordinatorPubKey
     ) Ownable() public {
 
-        // Set the verifier contract addresses
-        batchUstVerifier = _batchUstVerifier;
+        // Deploy the verifier contracts
+        batchUstVerifier = new BatchUpdateStateTreeVerifier();
+        qvtVerifier = new QuadVoteTallyVerifier();
 
         // Set the sign-up duration
         signUpTimestamp = now;

--- a/contracts/ts/deploy.ts
+++ b/contracts/ts/deploy.ts
@@ -12,7 +12,6 @@ const Hasher = require('@maci-contracts/compiled/Hasher.json')
 const SignUpToken = require('@maci-contracts/compiled/SignUpToken.json')
 const SignUpTokenGatekeeper = require('@maci-contracts/compiled/SignUpTokenGatekeeper.json')
 
-const BatchUpdateStateTreeVerifier = require('@maci-contracts/compiled/BatchUpdateStateTreeVerifier.json')
 const MerkleTree = require('@maci-contracts/compiled/MerkleTree.json')
 const MACI = require('@maci-contracts/compiled/MACI.json')
 
@@ -65,9 +64,6 @@ const deployMaci = async (
     console.log('Deploying MiMC')
     const mimcContract = await deployer.deploy(MiMC, {})
 
-    console.log('Deploying BatchUpdateStateTreeVerifier')
-    const batchUpdateStateTreeVerifierContract = await deployer.deploy(BatchUpdateStateTreeVerifier, {})
-
     console.log('Deploying MACI')
     const maciContract = await deployer.deploy(
         MACI,
@@ -75,7 +71,6 @@ const deployMaci = async (
         config.merkleTrees.messageTreeDepth,
         config.merkleTrees.stateTreeDepth,
         config.merkleTrees.voteOptionTreeDepth,
-        batchUpdateStateTreeVerifierContract.contractAddress,
         signUpTokenGatekeeperAddress,
         config.maci.signupDurationInSeconds.toString(),
         config.maci.initialVoiceCreditBalance,
@@ -87,7 +82,6 @@ const deployMaci = async (
 
     return {
         mimcContract,
-        batchUpdateStateTreeVerifierContract,
         maciContract,
     }
 }
@@ -152,7 +146,6 @@ const main = async () => {
 
     const {
         mimcContract,
-        batchUpdateStateTreeVerifierContract,
         maciContract,
     } = await deployMaci(
         deployer,
@@ -161,7 +154,6 @@ const main = async () => {
 
     const addresses = {
         MiMC: mimcContract.contractAddress,
-        BatchUpdateStateTreeVerifier: batchUpdateStateTreeVerifierContract.contractAddress,
         MACI: maciContract.contractAddress,
     }
 


### PR DESCRIPTION
This simplifies the deployment process.