### PR TITLE
[domainobjs] Create a Keypair, PrivKey, and PubKey domain object so it is easier to pass keys to contracts and circuits

### DIFF
--- a/circuits/package.json
+++ b/circuits/package.json
@@ -24,7 +24,7 @@
         "test-publicKey-debug": "node --inspect-brk ./node_modules/.bin/jest PublicKey.test.ts",
         "test-decrypt": "jest Decrypt.test.ts",
         "test-decrypt-debug": "node --inspect-brk ./node_modules/.bin/jest Decrypt.test.ts",
-        "test-updateStateTree": "jest UpdateStateTree.test.ts",
+        "test-updateStateTree": "jest ts/__tests__/UpdateStateTree.test.ts",
         "test-updateStateTree-debug": "node --inspect-brk ./node_modules/.bin/jest UpdateStateTree.test.ts",
         "test-batchUpdateStateTree": "jest BatchUpdateStateTree.test.ts",
         "test-batchUpdateStateTree-debug": "node --inspect-brk ./node_modules/.bin/jest BatchUpdateStateTree.test.ts"

--- a/circuits/ts/__tests__/Decrypt.test.ts
+++ b/circuits/ts/__tests__/Decrypt.test.ts
@@ -3,14 +3,13 @@ import { Circuit } from 'snarkjs'
 const compiler = require('circom')
 
 import { 
-    genKeyPair,
     bigInt,
     stringifyBigInts,
     encrypt,
-    genEcdhSharedKey,
 } from 'maci-crypto'
 
 import {
+    Keypair,
     Command,
     Message,
 } from 'maci-domainobjs'
@@ -24,9 +23,9 @@ describe('Decryption circuit', () => {
     })
 
     it('Should decrypt a message inside the snark', async () => {
-        const keypair = genKeyPair()
-        const keypair2 = genKeyPair()
-        const sharedKey = genEcdhSharedKey(
+        const keypair = new Keypair()
+        const keypair2 = new Keypair()
+        const sharedKey = Keypair.genEcdhSharedKey(
             keypair.privKey,
             keypair2.pubKey,
         )

--- a/circuits/ts/__tests__/Ecdh.test.ts
+++ b/circuits/ts/__tests__/Ecdh.test.ts
@@ -3,31 +3,26 @@ import { Circuit } from 'snarkjs'
 const compiler = require('circom')
 
 import {
-    genKeyPair,
-    bigInt,
-    stringifyBigInts,
-    formatPrivKeyForBabyJub,
-    genEcdhSharedKey
-} from 'maci-crypto'
-
+    Keypair,
+} from 'maci-domainobjs'
 
 describe('Public key derivation circuit', () => {
     it('correctly computes a public key', async () => {
         const circuitDef = await compiler(path.join(__dirname, 'circuits', '../../../circom/test/ecdh_test.circom'))
         const circuit = new Circuit(circuitDef)
 
-        const keypair = genKeyPair()
-        const keypair2 = genKeyPair()
+        const keypair = new Keypair()
+        const keypair2 = new Keypair()
 
-        const ecdhSharedKey = genEcdhSharedKey(
+        const ecdhSharedKey = Keypair.genEcdhSharedKey(
             keypair.privKey,
             keypair2.pubKey,
         )
 
-        const circuitInputs = stringifyBigInts({
-            'private_key': formatPrivKeyForBabyJub(keypair.privKey),
-            'public_key': keypair2.pubKey,
-        })
+        const circuitInputs = {
+            'private_key': keypair.privKey.asCircuitInputs(),
+            'public_key': keypair2.pubKey.asCircuitInputs(),
+        }
 
         const witness = circuit.calculateWitness(circuitInputs)
         expect(circuit.checkWitness(witness)).toBeTruthy()

--- a/circuits/ts/__tests__/PublicKey.test.ts
+++ b/circuits/ts/__tests__/PublicKey.test.ts
@@ -9,24 +9,28 @@ import {
     formatPrivKeyForBabyJub,
 } from 'maci-crypto'
 
+import {
+    Keypair,
+} from 'maci-domainobjs'
+
 
 describe('Public key derivation circuit', () => {
     it('correctly computes a public key', async () => {
         const circuitDef = await compiler(path.join(__dirname, 'circuits', '../../../circom/test/publicKey_test.circom'))
         const circuit = new Circuit(circuitDef)
 
-        const keypair = genKeyPair()
+        const keypair = new Keypair()
 
-        const circuitInputs = stringifyBigInts({
-            'private_key': formatPrivKeyForBabyJub(keypair.privKey),
-        })
+        const circuitInputs = {
+            'private_key': keypair.privKey.asCircuitInputs(),
+        }
 
         const witness = circuit.calculateWitness(circuitInputs)
         expect(circuit.checkWitness(witness)).toBeTruthy()
 
         const derivedPubkey0 = witness[circuit.getSignalIdx('main.public_key[0]')].toString()
         const derivedPubkey1 = witness[circuit.getSignalIdx('main.public_key[1]')].toString()
-        expect(derivedPubkey0).toEqual(keypair.pubKey[0].toString())
-        expect(derivedPubkey1).toEqual(keypair.pubKey[1].toString())
+        expect(derivedPubkey0).toEqual(keypair.pubKey.rawPubKey[0].toString())
+        expect(derivedPubkey1).toEqual(keypair.pubKey.rawPubKey[1].toString())
     })
 })

--- a/contracts/ts/__tests__/Maci.test.ts
+++ b/contracts/ts/__tests__/Maci.test.ts
@@ -24,6 +24,8 @@ import {
 import {
     Message,
     Command,
+    Keypair,
+    PubKey,
 } from 'maci-domainobjs'
 
 const accounts = genTestAccounts(5)
@@ -36,26 +38,25 @@ describe('MACI', () => {
 
     // Set up users
     const coordinatorPrivKey = bigInt(config.maci.coordinatorPrivKey)
-    const coordinatorPubKey = genPubKey(coordinatorPrivKey)
+    const coordinatorPubKey = new PubKey(genPubKey(coordinatorPrivKey))
 
-    // TODO: create a domain object for public keys
     const user1 = {
         wallet: accounts[1],
-        keypair: genKeyPair(),
+        keypair: new Keypair(),
     }
 
     const user2 = {
         wallet: accounts[2],
-        keypair: genKeyPair(),
+        keypair: new Keypair(),
     }
 
     const badUser = {
         wallet: accounts[3],
-        keypair: genKeyPair(),
+        keypair: new Keypair(),
     }
 
-    const encKeypair = genKeyPair()
-    const ecdhSharedKey = genEcdhSharedKey(encKeypair.privKey, coordinatorPubKey)
+    const encKeypair = new Keypair()
+    const ecdhSharedKey = Keypair.genEcdhSharedKey(encKeypair.privKey, coordinatorPubKey)
     const command: Command = new Command(
         bigInt(10),
         encKeypair.pubKey,
@@ -131,10 +132,7 @@ describe('MACI', () => {
 
             try {
                 await contract.signUp(
-                    { 
-                        x: user1.keypair.pubKey[0].toString(),
-                        y: user1.keypair.pubKey[1].toString(),
-                    },
+                    user1.keypair.pubKey.asContractParam(),
                     ethers.utils.defaultAbiCoder.encode(['uint256'], [2]),
                     { gasLimit: 2000000 },
                 )
@@ -151,10 +149,7 @@ describe('MACI', () => {
                 wallet,
             )
             const tx = await contract.signUp(
-                { 
-                    x: user1.keypair.pubKey[0].toString(),
-                    y: user1.keypair.pubKey[1].toString(),
-                },
+                user1.keypair.pubKey.asContractParam(),
                 ethers.utils.defaultAbiCoder.encode(['uint256'], [1]),
                 { gasLimit: 2000000 },
             )
@@ -196,10 +191,7 @@ describe('MACI', () => {
                     wallet2,
                 )
                 await maciContract2.signUp(
-                    { 
-                        x: user2.keypair.pubKey[0].toString(),
-                        y: user2.keypair.pubKey[1].toString(),
-                    },
+                    user2.keypair.pubKey.asContractParam(),
                     ethers.utils.defaultAbiCoder.encode(['uint256'], [1]),
                     { gasLimit: 2000000 },
                 )
@@ -233,10 +225,7 @@ describe('MACI', () => {
             try {
                 await maciContract.publishMessage(
                     message.asContractParam(),
-                    {
-                        x: encKeypair.pubKey[0].toString(),
-                        y: encKeypair.pubKey[1].toString(),
-                    },
+                    encKeypair.pubKey.asContractParam(),
                 )
             } catch (e) {
                 expect(e.message.endsWith('MACI: the sign-up period is not over')).toBeTruthy()
@@ -248,10 +237,7 @@ describe('MACI', () => {
             await timeTravel(deployer.provider, config.maci.signupDurationInSeconds + 1)
             try {
                 await maciContract.signUp(
-                    { 
-                        x: user1.keypair.pubKey[0].toString(),
-                        y: user1.keypair.pubKey[1].toString(),
-                    },
+                    user1.keypair.pubKey.asContractParam(),
                     ethers.utils.defaultAbiCoder.encode(['uint256'], [1]),
                     { gasLimit: 2000000 },
                 )
@@ -276,10 +262,7 @@ describe('MACI', () => {
 
             const tx = await maciContract.publishMessage(
                 message.asContractParam(),
-                {
-                    x: encKeypair.pubKey[0].toString(),
-                    y: encKeypair.pubKey[1].toString(),
-                },
+                encKeypair.pubKey.asContractParam(),
             )
             const receipt = await tx.wait()
             expect(receipt.status).toEqual(1)

--- a/crypto/ts/__tests__/Crypto.test.ts
+++ b/crypto/ts/__tests__/Crypto.test.ts
@@ -1,7 +1,7 @@
 import {
     genPrivKey,
     genPubKey,
-    genKeyPair,
+    genKeypair,
     genEcdhSharedKey,
     encrypt,
     decrypt,
@@ -15,8 +15,8 @@ import * as snarkjs from 'snarkjs'
 const SNARK_FIELD_SIZE = snarkjs.bigInt('21888242871839275222246405745257275088548364400416034343698204186575808495617')
 
 describe('Cryptographic operations', () => {
-    const { privKey, pubKey } = genKeyPair()
-    const k = genKeyPair()
+    const { privKey, pubKey } = genKeypair()
+    const k = genKeypair()
 
     const privKey1 = k.privKey
     const pubKey1 = k.pubKey

--- a/crypto/ts/index.ts
+++ b/crypto/ts/index.ts
@@ -13,9 +13,9 @@ type PubKey = SnarkBigInt[]
 type EcdhSharedKey = SnarkBigInt
 type Plaintext = SnarkBigInt[]
 
-interface KeyPair {
-    privKey: PrivKey,
-        pubKey: PubKey,
+interface Keypair {
+    privKey: PrivKey;
+    pubKey: PubKey;
 }
 
 interface Ciphertext {
@@ -174,13 +174,13 @@ const genPubKey = (privKey: PrivKey): PubKey => {
     return pubKey
 }
 
-const genKeyPair = (): KeyPair => {
+const genKeypair = (): Keypair => {
     const privKey = genPrivKey()
     const pubKey = genPubKey(privKey)
 
-    const keypair: KeyPair = { privKey, pubKey }
+    const Keypair: Keypair = { privKey, pubKey }
 
-    return keypair
+    return Keypair
 }
 
 /*
@@ -314,7 +314,7 @@ export {
     genRandomSalt,
     genPrivKey,
     genPubKey,
-    genKeyPair,
+    genKeypair,
     genEcdhSharedKey,
     encrypt,
     decrypt,
@@ -325,7 +325,7 @@ export {
     verifySignature,
     PrivKey,
     PubKey,
-    KeyPair,
+    Keypair,
     EcdhSharedKey,
     Ciphertext,
     Plaintext,

--- a/domainobjs/ts/__tests__/DomainObjs.test.ts
+++ b/domainobjs/ts/__tests__/DomainObjs.test.ts
@@ -1,6 +1,7 @@
 import {
     Command,
     Message,
+    Keypair,
 } from '../'
 
 import {
@@ -8,27 +9,26 @@ import {
     sign,
     decrypt,
     verifySignature,
-    genKeyPair,
-    genEcdhSharedKey,
+    genKeypair,
     bigInt,
 } from 'maci-crypto'
 
 describe('Domain objects', () => {
-    const { privKey, pubKey } = genKeyPair()
-    const k = genKeyPair()
+    const { privKey, pubKey } = new Keypair()
+    const k = new Keypair()
 
     const privKey1 = k.privKey
     const pubKey1 = k.pubKey
 
-    const encKeypair = genKeyPair()
+    const encKeypair = new Keypair()
     const encPrivKey = k.privKey
     const encPubKey = k.pubKey
 
-    const newKeypair = genKeyPair()
+    const newKeypair = new Keypair()
     const newPrivKey = k.privKey
     const newPubKey = k.pubKey
 
-    const ecdhSharedKey = genEcdhSharedKey(privKey, pubKey1)
+    const ecdhSharedKey = Keypair.genEcdhSharedKey(privKey, pubKey1)
 
     const command: Command = new Command(
         bigInt(10),


### PR DESCRIPTION
This PR:

1. Encapsulates `maci-crypto`'s `Keypair`, `PubKey`, and `PrivKey` in domain objects, so that we have `asCircuitInputs()` and `asContractParams()` functions available.
2. Renames `KeyPair` to `Keypair`