### PR TITLE
renamed hashPair to hashLeftRight and hashMulti to hash

### DIFF
--- a/contracts/sol/DomainObjs.sol
+++ b/contracts/sol/DomainObjs.sol
@@ -30,7 +30,7 @@ contract DomainObjs is Hasher {
         plaintext[3] = _stateLeaf.voiceCreditBalance;
         plaintext[4] = _stateLeaf.nonce;
 
-        return hashMulti(plaintext, 0);
+        return hash(plaintext);
     }
 
     function hashMessage(Message memory _message) public pure returns (uint256) {
@@ -42,6 +42,6 @@ contract DomainObjs is Hasher {
             plaintext[i+1] = _message.data[i];
         }
 
-        return hashMulti(plaintext, 0);
+        return hash(plaintext);
     }
 }

--- a/contracts/sol/Hasher.sol
+++ b/contracts/sol/Hasher.sol
@@ -12,7 +12,7 @@ library CircomLib {
 }
 
 contract Hasher {
-    function hashMulti(uint256[] memory array, uint256 key) public pure returns (uint256) {
+    function hash(uint256[] memory array) public pure returns (uint256) {
         uint256 k = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
         uint256 R = 0;
         uint256 C = 0;
@@ -20,17 +20,17 @@ contract Hasher {
         for (uint256 i = 0; i < array.length; i++)
         {
             R = addmod(R, array[i], k);
-            (R, C) = CircomLib.MiMCSponge(R, C, key);
+            (R, C) = CircomLib.MiMCSponge(R, C, 0);
         }
         
         return R;
     }
 
-    function hashPair(uint256 left, uint256 right) public pure returns (uint256) {
+    function hashLeftRight(uint256 left, uint256 right) public pure returns (uint256) {
         uint256[] memory arr = new uint256[](2);
         arr[0] = left;
         arr[1] = right;
 
-        return hashMulti(arr, 0);
+        return hash(arr);
     }
 }

--- a/contracts/sol/MACI.sol
+++ b/contracts/sol/MACI.sol
@@ -1,7 +1,6 @@
 pragma experimental ABIEncoderV2;
 pragma solidity ^0.5.0;
 
-import { Hasher } from "./Hasher.sol";
 import { DomainObjs } from './DomainObjs.sol';
 import { MerkleTree } from "./MerkleTree.sol";
 import { SignUpGatekeeper } from "./gatekeepers/SignUpGatekeeper.sol";
@@ -10,7 +9,7 @@ import { QuadVoteTallyVerifier } from "./QuadVoteTallyVerifier.sol";
 
 import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
 
-contract MACI is Hasher, Ownable, DomainObjs {
+contract MACI is Ownable, DomainObjs {
 
     // Verifier Contracts
     BatchUpdateStateTreeVerifier internal batchUstVerifier;

--- a/contracts/sol/MerkleTree.sol
+++ b/contracts/sol/MerkleTree.sol
@@ -68,12 +68,12 @@ contract MerkleTree is Ownable, Hasher {
         filledSubtrees.push(zeros[0]);
 
         for (uint8 i = 1; i < depth; i++) {
-            zeros.push(hashPair(zeros[i-1], zeros[i-1]));
+            zeros.push(hashLeftRight(zeros[i-1], zeros[i-1]));
             filledSubtrees.push(zeros[i]);
         }
 
         // Calculate current root
-        root = hashPair(zeros[depth - 1], zeros[depth - 1]);
+        root = hashLeftRight(zeros[depth - 1], zeros[depth - 1]);
         nextLeafIndex = 0;
     }
 
@@ -102,7 +102,7 @@ contract MerkleTree is Ownable, Hasher {
                 right = currentLevelHash;
             }
 
-            currentLevelHash = hashPair(left, right);
+            currentLevelHash = hashLeftRight(left, right);
             currentIndex /= 2;
         }
 
@@ -145,7 +145,7 @@ contract MerkleTree is Ownable, Hasher {
                 right = currentLevelHash;
             }
 
-            currentLevelHash = hashPair(left, right);
+            currentLevelHash = hashLeftRight(left, right);
             currentIndex /= 2;
         }
 
@@ -163,7 +163,7 @@ contract MerkleTree is Ownable, Hasher {
                 right = currentLevelHash;
             }
 
-            currentLevelHash = hashPair(left, right);
+            currentLevelHash = hashLeftRight(left, right);
             currentIndex /= 2;
         }
 
@@ -173,11 +173,6 @@ contract MerkleTree is Ownable, Hasher {
         emit LeafUpdated(leaf, leafIndex);
     }
 
-    function hashLeftRight(uint256 left, uint256 right) public pure returns (uint256) {
-        return hashPair(left, right);
-    }
-
-    /*** Getters ***/
     function getRoot() public view returns (uint256) {
         return root;
     }

--- a/contracts/ts/__tests__/Hasher.test.ts
+++ b/contracts/ts/__tests__/Hasher.test.ts
@@ -34,31 +34,31 @@ describe('Hasher', () => {
         hasherContract = await deployer.deploy(Hasher, { CircomLib: mimcContract.contractAddress })
     })
 
-    it('maci-crypto.hashLeftRight should match hasher.hashPair', async () => {
+    it('maci-crypto.hashLeftRight should match hasher.hashLeftRight', async () => {
         const left = genRandomSalt()
         const right = genRandomSalt()
         const hashed = hashLeftRight(left, right)
 
-        const onChainHash = await hasherContract.hashPair(left.toString(), right.toString())
+        const onChainHash = await hasherContract.hashLeftRight(left.toString(), right.toString())
         expect(onChainHash.toString()).toEqual(hashed.toString())
     })
 
-    it('maci-crypto.hash should match hasher.hashMulti', async () => {
+    it('maci-crypto.hash should match hasher.hash', async () => {
         let values: string[] = []
         for (let i=0; i < 10; i++) {
             values.push(genRandomSalt().toString())
         }
         const hashed = hash(values)
 
-        const onChainHash = await hasherContract.hashMulti(values, 0)
+        const onChainHash = await hasherContract.hash(values)
         expect(onChainHash.toString()).toEqual(hashed.toString())
     })
 
-    it('maci-crypto.hashOne should match hasher.hashMulti with one value', async () => {
+    it('maci-crypto.hashOne should match hasher.hash with one value', async () => {
         let values = [genRandomSalt().toString()]
         const hashed = hash(values)
 
-        const onChainHash = await hasherContract.hashMulti(values, 0)
+        const onChainHash = await hasherContract.hash(values)
         expect(onChainHash.toString()).toEqual(hashed.toString())
     })
 })


### PR DESCRIPTION
1. Renames `Hasher.hashMulti` to `Hasher.hash` with a default key 0 so as to match `maci-crypto`'s hash() function
2. Renames `Hasher.hashPair` to `hashLeftRight` for consistency with `maci-crypto`